### PR TITLE
Refactor logging for clarity and consistency across components

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -21,7 +21,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
       id: buildx

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build and push
       run: |

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ err
 log
 # JSON files with hash names (job state files)
 [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*.json
+.venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   # Python
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.0
+    rev: v0.15.2
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,16 +29,25 @@ repos:
     hooks:
       - id: velin
         args: ["--write"]
-  # Python inside docs
-  - repo: https://github.com/asottile/blacken-docs
-    rev: 1.20.0
+  # markdown
+  - repo: https://github.com/hukkin/mdformat
+    rev: 1.0.0
     hooks:
-      - id: blacken-docs
-  # markdown, yaml
+      - id: mdformat
+        additional_dependencies:
+          # - mdformat-myst==0.3.0
+          # See https://github.com/executablebooks/mdformat-myst/issues/13
+          - "git+https://github.com/njzjz-bothub/mdformat-myst@d9c414e#egg=mdformat-myst"
+          - mdformat-ruff==0.1.3
+          - mdformat-web==0.2.0
+          - mdformat-config==0.2.1
+          - mdformat-beautysh==1.0.0
+          - mdformat-gfm-alerts==2.0.0
+  # yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
-        types_or: [markdown, yaml]
+        types_or: [yaml]
         # workflow files cannot be modified by pre-commit.ci
         exclude: ^(\.github/workflows|conda)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Always reference these instructions first and fallback to search or bash command
   pre-commit run --all-files
   ```
 
-  - **TIMING: Linting takes <5 seconds.**
+  - **TIMING: Linting takes \<5 seconds.**
   - **Fallback:** If pre-commit fails with network issues, use `ruff check . && ruff format --check .`
 
 - **Run type checking:**
@@ -61,6 +61,7 @@ Always reference these instructions first and fallback to search or bash command
   ```
 
 - **Run sample job dispatch script:**
+
   ```bash
   python examples/dpdisp_run.py
   ```

--- a/doc/agent-skills.md
+++ b/doc/agent-skills.md
@@ -1,0 +1,26 @@
+# Agent Skills
+
+DPDispatcher provides official [Agent Skills](https://agentskills.io/what-are-skills) to submit jobs using an agent.
+
+## List of skills
+
+- `dpdisp-submit`: Run Shell commands as computational jobs, on local machines or HPC clusters, through Shell, Slurm, PBS, LSF, Bohrium, etc.
+
+## Install skills
+
+### If you are human beings
+
+The easiest way is to send this page to the agent and ask the agent to install skills for you.
+Users usually do not need to perform manual installation.
+
+### If you are an agent
+
+1. Clone [deepmodeling/dpdispatcher](https://github.com/deepmodeling/dpdispatcher).
+1. Copy required skill directories from `skills/` into your workspace skills directory.
+1. Refresh/restart session so skills are reloaded.
+
+## Minimal verification
+
+Ask the agent to run this task:
+
+- "run `echo hello world` on the local machine using dpdisp-submit"

--- a/doc/env.md
+++ b/doc/env.md
@@ -5,31 +5,26 @@ When launching a job, dpdispatcher sets the following environment variables acco
 :::{envvar} DPDISPATCHER_NUMBER_NODE
 
 The number of nodes required for each job.
-
 :::
 
 :::{envvar} DPDISPATCHER_CPU_PER_NODE
 
 CPU numbers of each node assigned to each job.
-
 :::
 
 :::{envvar} DPDISPATCHER_GPU_PER_NODE
 
 GPU numbers of each node assigned to each job.
-
 :::
 
 :::{envvar} DPDISPATCHER_QUEUE_NAME
 
 The queue name of batch job scheduler system.
-
 :::
 
 :::{envvar} DPDISPATCHER_GROUP_SIZE
 
 The number of tasks in a job. 0 means infinity.
-
 :::
 
 These environment variables can be used in the {dargs:argument}`command <task/command>`, for example, `mpirun -n ${DPDISPATCHER_CPU_PER_NODE} xx.run`.

--- a/doc/examples/expanse.md
+++ b/doc/examples/expanse.md
@@ -5,20 +5,26 @@
 The machine parameters are provided below. Expanse uses the SLURM workload manager for job scheduling. {ref}`remote_root <machine/remote_root>` has been created in advance. It's worth metioned that we do not recommend to use the password, so [SSH keys](https://www.ssh.com/academy/ssh/key) are used instead to improve security.
 
 ```{literalinclude} ../../examples/machine/expanse.json
-:language: json
-:linenos:
+---
+language: json
+linenos:
+---
 ```
 
 Expanse's standard compute nodes are each powered by two 64-core AMD EPYC 7742 processors and contain 256 GB of DDR4 memory. Here, we request one node with 32 cores and 16 GB memory from the `shared` partition. Expanse does not support `--gres=gpu:0` command, so we use {ref}`custom_gpu_line <resources[Slurm]/kwargs/custom_gpu_line>` to customize the statement.
 
 ```{literalinclude} ../../examples/resources/expanse_cpu.json
-:language: json
-:linenos:
+---
+language: json
+linenos:
+---
 ```
 
 The following task parameter runs a DeePMD-kit task, forwarding an input file and backwarding graph files. Here, the data set will be used among all the tasks, so it is not included in the {ref}`forward_files <task/forward_files>`. Instead, it should be included in the submission's {ref}`forward_common_files <task/forward_common_files>`.
 
 ```{literalinclude} ../../examples/task/deepmd-kit.json
-:language: json
-:linenos:
+---
+language: json
+linenos:
+---
 ```

--- a/doc/examples/g16.md
+++ b/doc/examples/g16.md
@@ -3,8 +3,10 @@
 Typically, a task will retry three times if the exit code is not zero. Sometimes, one may allow non-zero code. For example, when running large amounts of Gaussian 16 single-point calculation tasks, some of the Gaussian 16 tasks may throw SCF errors and return a non-zero code. One can append `||:` to the command:
 
 ```{literalinclude} ../../examples/task/g16.json
-:language: json
-:linenos:
+---
+language: json
+linenos:
+---
 ```
 
 This command ensures the task will always provide zero code.

--- a/doc/examples/shell.md
+++ b/doc/examples/shell.md
@@ -3,15 +3,19 @@
 In this example, we are going to show how to run multiple MD tasks on a GPU workstation. This workstation does not install any job scheduling packages installed, so we will use `Shell` as {ref}`batch_type <machine/batch_type>`.
 
 ```{literalinclude} ../../examples/machine/mandu.json
-:language: json
-:linenos:
+---
+language: json
+linenos:
+---
 ```
 
 The workstation has 48 cores of CPUs and 8 RTX3090 cards. Here we hope each card runs 6 tasks at the same time, as each task does not consume too many GPU resources. Thus, {ref}`strategy/if_cuda_multi_devices <resources/strategy/if_cuda_multi_devices>` is set to `true` and {ref}`para_deg <resources/para_deg>` is set to 6.
 
 ```{literalinclude} ../../examples/resources/mandu.json
-:language: json
-:linenos:
+---
+language: json
+linenos:
+---
 ```
 
 Note that {ref}`group_size <resources/group_size>` should be set to `0` (means infinity) to ensure there is only one job and avoid running multiple jobs at the same time.

--- a/doc/examples/template.md
+++ b/doc/examples/template.md
@@ -3,14 +3,18 @@
 When submitting jobs to some clusters, such as the [Tiger Cluster](https://researchcomputing.princeton.edu/systems/tiger) at Princeton University, the Slurm header is quite different from the standard one. In this case, DPDispatcher allows users to customize the templates by setting {dargs:argument}`strategy/customized_script_header_template_file <resources/strategy/customized_script_header_template_file>` to a template file:
 
 ```{literalinclude} ../../examples/resources/tiger.json
-:language: json
-:linenos:
+---
+language: json
+linenos:
+---
 ```
 
 `template.slurm` is the template file, where {meth}`str.format` is used to format the template with [Resources Parameters](resources):
 
 ```{literalinclude} ../../examples/resources/template.slurm
-:linenos:
+---
+linenos:
+---
 ```
 
 See [Python Format String Syntax](https://docs.python.org/3/library/string.html#formatstrings) for how to insert parameters inside the template.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -99,8 +99,13 @@ and `task.json` is
 {
   "command": "lmp -i input.lammps",
   "task_work_path": "bct-0/",
-  "forward_files": ["conf.lmp", "input.lammps"],
-  "backward_files": ["log.lammps"],
+  "forward_files": [
+    "conf.lmp",
+    "input.lammps"
+  ],
+  "backward_files": [
+    "log.lammps"
+  ],
   "outlog": "log",
   "errlog": "err"
 }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,6 +33,7 @@ Please cite the following paper if you use this project in your work:
    task
    env
    run
+   submit
    cli
    api/api
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,6 +34,7 @@ Please cite the following paper if you use this project in your work:
    env
    run
    submit
+   agent-skills
    cli
    api/api
 

--- a/doc/run.md
+++ b/doc/run.md
@@ -10,8 +10,10 @@ The script must include [inline script metadata](https://packaging.python.org/en
 An example of the script is shown below.
 
 ```{literalinclude} ../examples/dpdisp_run.py
-:language: py
-:linenos:
+---
+language: py
+linenos:
+---
 ```
 
 The PEP 723 metadata entries for `tool.dpdispatcher` are defined as follows:

--- a/doc/run.md
+++ b/doc/run.md
@@ -21,3 +21,14 @@ The PEP 723 metadata entries for `tool.dpdispatcher` are defined as follows:
 ```{eval-rst}
 .. include:: pep723.rst
 ```
+
+## `$ref` support
+
+`dpdisp run` supports loading external JSON/YAML snippets via `$ref` in `tool.dpdispatcher` metadata.
+For security reasons, this feature is disabled by default.
+
+Enable explicitly with:
+
+```sh
+dpdisp run script.py --allow-ref
+```

--- a/doc/submit.md
+++ b/doc/submit.md
@@ -27,3 +27,4 @@ The JSON entries for submission are defined as follows:
 
 - `--dry-run`: Only upload files without submitting.
 - `--exit-on-submit`: Exit after submitting without waiting for completion.
+- `--allow-ref`: Allow loading external JSON/YAML snippets through `$ref` (disabled by default for security).

--- a/doc/submit.md
+++ b/doc/submit.md
@@ -9,8 +9,10 @@ dpdisp submit submission.json
 The JSON file must contain the submission configuration. An example of the JSON file is shown below.
 
 ```{literalinclude} ../examples/submit_example.json
-:language: json
-:linenos:
+---
+language: json
+linenos:
+---
 ```
 
 The JSON entries for submission are defined as follows:

--- a/doc/submit.md
+++ b/doc/submit.md
@@ -1,0 +1,27 @@
+# Submit from JSON file
+
+DPDispatcher can submit a submission from a JSON file:
+
+```sh
+dpdisp submit submission.json
+```
+
+The JSON file must contain the submission configuration. An example of the JSON file is shown below.
+
+```{literalinclude} ../examples/submit_example.json
+:language: json
+:linenos:
+```
+
+The JSON entries for submission are defined as follows:
+
+```{eval-rst}
+.. dargs::
+   :module: dpdispatcher.entrypoints.submit
+   :func: submission_args
+```
+
+## Options
+
+- `--dry-run`: Only upload files without submitting.
+- `--exit-on-submit`: Exit after submitting without waiting for completion.

--- a/dpdispatcher/contexts/ssh_context.py
+++ b/dpdispatcher/contexts/ssh_context.py
@@ -178,7 +178,7 @@ class SSHSession:
                         key = pkey_class.from_private_key_file(
                             key_path, self.passphrase
                         )
-                    except paramiko.SSHException as e:
+                    except paramiko.SSHException:
                         pass
                     if key is not None:
                         break
@@ -200,7 +200,7 @@ class SSHSession:
             for pkey_class, filename in keyfiles:
                 try:
                     key = pkey_class.from_private_key_file(filename, self.passphrase)
-                except paramiko.SSHException as e:
+                except paramiko.SSHException:
                     pass
                 if key is not None:
                     break

--- a/dpdispatcher/dpdisp.py
+++ b/dpdispatcher/dpdisp.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from dpdispatcher.entrypoints.gui import start_dpgui
 from dpdispatcher.entrypoints.run import run
 from dpdispatcher.entrypoints.submission import handle_submission
+from dpdispatcher.entrypoints.submit import submit
 
 
 def main_parser() -> argparse.ArgumentParser:
@@ -94,6 +95,28 @@ def main_parser() -> argparse.ArgumentParser:
         type=str,
         help="Python script to run. PEP 723 metadata should be contained in this file.",
     )
+    ##########################################
+    # submit
+    parser_submit = subparsers.add_parser(
+        "submit",
+        help="Submit a submission from a JSON file.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser_submit.add_argument(
+        "filename",
+        type=str,
+        help="JSON file containing submission configuration.",
+    )
+    parser_submit.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only upload files without submitting.",
+    )
+    parser_submit.add_argument(
+        "--exit-on-submit",
+        action="store_true",
+        help="Exit after submitting without waiting for completion.",
+    )
     return parser
 
 
@@ -132,6 +155,12 @@ def main():
         )
     elif args.command == "run":
         run(filename=args.filename)
+    elif args.command == "submit":
+        submit(
+            filename=args.filename,
+            dry_run=args.dry_run,
+            exit_on_submit=args.exit_on_submit,
+        )
     elif args.command is None:
         pass
     else:

--- a/dpdispatcher/dpdisp.py
+++ b/dpdispatcher/dpdisp.py
@@ -95,6 +95,11 @@ def main_parser() -> argparse.ArgumentParser:
         type=str,
         help="Python script to run. PEP 723 metadata should be contained in this file.",
     )
+    parser_run.add_argument(
+        "--allow-ref",
+        action="store_true",
+        help="Allow loading external JSON/YAML snippets through `$ref`. Disabled by default for security.",
+    )
     ##########################################
     # submit
     parser_submit = subparsers.add_parser(
@@ -116,6 +121,11 @@ def main_parser() -> argparse.ArgumentParser:
         "--exit-on-submit",
         action="store_true",
         help="Exit after submitting without waiting for completion.",
+    )
+    parser_submit.add_argument(
+        "--allow-ref",
+        action="store_true",
+        help="Allow loading external JSON/YAML snippets through `$ref`. Disabled by default for security.",
     )
     return parser
 
@@ -154,12 +164,13 @@ def main():
             bind_all=args.bind_all,
         )
     elif args.command == "run":
-        run(filename=args.filename)
+        run(filename=args.filename, allow_ref=args.allow_ref)
     elif args.command == "submit":
         submit(
             filename=args.filename,
             dry_run=args.dry_run,
             exit_on_submit=args.exit_on_submit,
+            allow_ref=args.allow_ref,
         )
     elif args.command is None:
         pass

--- a/dpdispatcher/entrypoints/run.py
+++ b/dpdispatcher/entrypoints/run.py
@@ -3,7 +3,7 @@
 from dpdispatcher.run import run_pep723
 
 
-def run(*, filename: str):
+def run(*, filename: str, allow_ref: bool = False) -> None:
     with open(filename) as f:
         script = f.read()
-    run_pep723(script)
+    run_pep723(script, allow_ref=allow_ref)

--- a/dpdispatcher/entrypoints/submit.py
+++ b/dpdispatcher/entrypoints/submit.py
@@ -36,11 +36,9 @@ def submission_args() -> Argument:
         submission argument
     """
     machine_args = machine_dargs()
-    machine_args.fold_subdoc = True
     machine_args.doc = "Machine configuration. See related documentation for details."
 
     resources_args = resources_dargs(detail_kwargs=False)
-    resources_args.fold_subdoc = True
     resources_args.doc = (
         "Resources configuration. See related documentation for details."
     )

--- a/dpdispatcher/entrypoints/submit.py
+++ b/dpdispatcher/entrypoints/submit.py
@@ -1,13 +1,30 @@
 """Submit a submission from JSON file."""
 
 import json
-from typing import List
+import os
+from contextlib import contextmanager
+from threading import Lock
+from typing import Iterator, List
 
 from dargs import Argument
 
 from dpdispatcher.arginfo import machine_dargs, resources_dargs, task_dargs
 from dpdispatcher.machine import Machine
 from dpdispatcher.submission import Resources, Submission, Task
+
+_CWD_LOCK = Lock()
+
+
+@contextmanager
+def _temporary_chdir(path: str) -> Iterator[None]:
+    """Temporarily switch CWD in a thread-safe scope for dargs `$ref` resolution."""
+    with _CWD_LOCK:
+        cwd = os.getcwd()
+        try:
+            os.chdir(path)
+            yield
+        finally:
+            os.chdir(cwd)
 
 
 def submission_args() -> Argument:
@@ -66,43 +83,60 @@ def submission_args() -> Argument:
     )
 
 
-def load_submission_from_json(json_path: str) -> Submission:
+def load_submission_from_json(json_path: str, allow_ref: bool = False) -> Submission:
     """Load a Submission from a JSON file.
 
     Parameters
     ----------
     json_path : str
         Path to the JSON file.
+    allow_ref : bool, default=False
+        Whether to allow loading external JSON/YAML snippets via ``$ref``.
+        Disabled by default for security.
 
     Returns
     -------
     Submission
         Submission instance.
     """
-    with open(json_path, encoding="utf-8") as f:
-        submission_dict = json.load(f)
+    json_abspath = os.path.abspath(json_path)
+    json_dir = os.path.dirname(json_abspath)
+    with _temporary_chdir(json_dir):
+        with open(json_abspath, encoding="utf-8") as f:
+            submission_dict = json.load(f)
 
-    # Normalize and check with arginfo
-    base = submission_args()
-    submission_dict = base.normalize_value(submission_dict, trim_pattern="_*")
-    base.check_value(submission_dict, strict=False)
+        # Normalize and check with arginfo
+        base = submission_args()
+        submission_dict = base.normalize_value(
+            submission_dict, trim_pattern="_*", allow_ref=allow_ref
+        )
+        base.check_value(submission_dict, strict=False, allow_ref=allow_ref)
 
     # Create Task list
-    task_list = [Task.load_from_dict(task) for task in submission_dict["task_list"]]
+    task_list = [
+        Task.load_from_dict(task, allow_ref=allow_ref)
+        for task in submission_dict["task_list"]
+    ]
 
     # Create Submission
     return Submission(
         work_base=submission_dict["work_base"],
         forward_common_files=submission_dict["forward_common_files"],
         backward_common_files=submission_dict["backward_common_files"],
-        machine=Machine.load_from_dict(submission_dict["machine"]),
-        resources=Resources.load_from_dict(submission_dict["resources"]),
+        machine=Machine.load_from_dict(submission_dict["machine"], allow_ref=allow_ref),
+        resources=Resources.load_from_dict(
+            submission_dict["resources"], allow_ref=allow_ref
+        ),
         task_list=task_list,
     )
 
 
 def submit(
-    *, filename: str, dry_run: bool = False, exit_on_submit: bool = False
+    *,
+    filename: str,
+    dry_run: bool = False,
+    exit_on_submit: bool = False,
+    allow_ref: bool = False,
 ) -> None:
     """Submit a submission from a JSON file.
 
@@ -114,6 +148,9 @@ def submit(
         If True, only upload files without submitting.
     exit_on_submit : bool
         If True, exit after submitting without waiting for completion.
+    allow_ref : bool, default=False
+        Whether to allow loading external JSON/YAML snippets via ``$ref``.
+        Disabled by default for security.
     """
-    submission = load_submission_from_json(filename)
+    submission = load_submission_from_json(filename, allow_ref=allow_ref)
     submission.run_submission(dry_run=dry_run, exit_on_submit=exit_on_submit)

--- a/dpdispatcher/entrypoints/submit.py
+++ b/dpdispatcher/entrypoints/submit.py
@@ -1,0 +1,119 @@
+"""Submit a submission from JSON file."""
+
+import json
+from typing import List
+
+from dargs import Argument
+
+from dpdispatcher.arginfo import machine_dargs, resources_dargs, task_dargs
+from dpdispatcher.machine import Machine
+from dpdispatcher.submission import Resources, Submission, Task
+
+
+def submission_args() -> Argument:
+    """Return the argument parser for submission JSON.
+
+    Returns
+    -------
+    Argument
+        submission argument
+    """
+    machine_args = machine_dargs()
+    machine_args.fold_subdoc = True
+    machine_args.doc = "Machine configuration. See related documentation for details."
+
+    resources_args = resources_dargs(detail_kwargs=False)
+    resources_args.fold_subdoc = True
+    resources_args.doc = (
+        "Resources configuration. See related documentation for details."
+    )
+
+    task_args = task_dargs()
+    task_args.name = "task_list"
+    task_args.doc = "List of tasks to execute."
+    task_args.repeat = True
+    task_args.dtype = (list,)
+
+    return Argument(
+        "submission",
+        dtype=dict,
+        doc="Submission configuration",
+        sub_fields=[
+            Argument(
+                "work_base",
+                dtype=str,
+                optional=False,
+                doc="Base directory for the work",
+            ),
+            Argument(
+                "forward_common_files",
+                dtype=List[str],
+                optional=True,
+                default=[],
+                doc="Common files to forward to the remote machine",
+            ),
+            Argument(
+                "backward_common_files",
+                dtype=List[str],
+                optional=True,
+                default=[],
+                doc="Common files to backward from the remote machine",
+            ),
+            machine_args,
+            resources_args,
+            task_args,
+        ],
+    )
+
+
+def load_submission_from_json(json_path: str) -> Submission:
+    """Load a Submission from a JSON file.
+
+    Parameters
+    ----------
+    json_path : str
+        Path to the JSON file.
+
+    Returns
+    -------
+    Submission
+        Submission instance.
+    """
+    with open(json_path, encoding="utf-8") as f:
+        submission_dict = json.load(f)
+
+    # Normalize and check with arginfo
+    base = submission_args()
+    submission_dict = base.normalize_value(submission_dict, trim_pattern="_*")
+    base.check_value(submission_dict, strict=False)
+
+    # Create Task list
+    task_list = [Task.load_from_dict(task) for task in submission_dict["task_list"]]
+
+    # Create Submission
+    return Submission(
+        work_base=submission_dict["work_base"],
+        forward_common_files=submission_dict["forward_common_files"],
+        backward_common_files=submission_dict["backward_common_files"],
+        machine=Machine.load_from_dict(submission_dict["machine"]),
+        resources=Resources.load_from_dict(submission_dict["resources"]),
+        task_list=task_list,
+    )
+
+
+def submit(
+    *, filename: str, dry_run: bool = False, exit_on_submit: bool = False
+) -> None:
+    """Submit a submission from a JSON file.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the JSON file.
+    dry_run : bool
+        If True, only upload files without submitting.
+    exit_on_submit : bool
+        If True, exit after submitting without waiting for completion.
+    """
+    submission = load_submission_from_json(filename)
+    submission.run_submission(dry_run=dry_run, exit_on_submit=exit_on_submit)

--- a/dpdispatcher/machine.py
+++ b/dpdispatcher/machine.py
@@ -135,7 +135,24 @@ class Machine(metaclass=ABCMeta):
         return machine
 
     @classmethod
-    def load_from_dict(cls, machine_dict):
+    def load_from_dict(cls, machine_dict: dict, allow_ref: bool = False) -> "Machine":
+        """Load a Machine from a dict.
+
+        Parameters
+        ----------
+        machine_dict : dict
+            Machine configuration dict.
+        allow_ref : bool, default=False
+            Whether to allow loading external JSON/YAML snippets via ``$ref``.
+            Disabled by default for security.
+        """
+        # normalize/check so top-level $ref can be resolved before dispatch
+        base = cls.arginfo()
+        machine_dict = base.normalize_value(
+            machine_dict, trim_pattern="_*", allow_ref=allow_ref
+        )
+        base.check_value(machine_dict, strict=False, allow_ref=allow_ref)
+
         batch_type = machine_dict["batch_type"]
         try:
             machine_class = cls.subclasses_dict[batch_type]
@@ -145,9 +162,7 @@ class Machine(metaclass=ABCMeta):
             )
             raise e
         # check dict
-        base = cls.arginfo()
-        machine_dict = base.normalize_value(machine_dict, trim_pattern="_*")
-        base.check_value(machine_dict, strict=False)
+        # machine_dict has already been normalized/checked above
 
         context = BaseContext.load_from_dict(machine_dict)
         retry_count = machine_dict.get("retry_count", 3)
@@ -167,7 +182,9 @@ class Machine(metaclass=ABCMeta):
         machine_dict["retry_count"] = self.retry_count
         # normalize the dict
         base = self.arginfo()
-        machine_dict = base.normalize_value(machine_dict, trim_pattern="_*")
+        machine_dict = base.normalize_value(
+            machine_dict, trim_pattern="_*", allow_ref=False
+        )
         return machine_dict
 
     def __eq__(self, other):

--- a/dpdispatcher/run.py
+++ b/dpdispatcher/run.py
@@ -54,10 +54,8 @@ def read_pep723(script: str) -> Optional[dict]:
 def pep723_args() -> Argument:
     """Return the argument parser for PEP 723 metadata."""
     machine_args = machine_dargs()
-    machine_args.fold_subdoc = True
     machine_args.doc = "Machine configuration. See related documentation for details."
     resources_args = resources_dargs(detail_kwargs=False)
-    resources_args.fold_subdoc = True
     resources_args.doc = (
         "Resources configuration. See related documentation for details."
     )

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -167,16 +167,14 @@ class Submission:
     def register_task(self, task):
         if self.belonging_jobs:
             raise RuntimeError(
-                "Not allowed to register tasks after generating jobs. "
-                f"submission hash error {self}"
+                f"Not allowed to register tasks after generating jobs. submission hash error {self}"
             )
         self.belonging_tasks.append(task)
 
     def register_task_list(self, task_list):
         if self.belonging_jobs:
             raise RuntimeError(
-                "Not allowed to register tasks after generating jobs. "
-                f"submission hash error {self}"
+                f"Not allowed to register tasks after generating jobs. submission hash error {self}"
             )
         self.belonging_tasks.extend(task_list)
 
@@ -219,9 +217,9 @@ class Submission:
         self.try_recover_from_json()
         self.update_submission_state()
         if self.check_all_finished():
-            dlog.info("info:check_all_finished: True")
+            dlog.info("check_all_finished: True")
         else:
-            dlog.info("info:check_all_finished: False")
+            dlog.info("check_all_finished: False")
             self.upload_jobs()
             if dry_run is True:
                 dlog.info(f"submission succeeded: {self.submission_hash}")
@@ -342,7 +340,7 @@ class Submission:
                 continue
             job.get_job_state()
             dlog.debug(
-                f"debug:update_submission_state: job: {job.job_hash}, {job.job_id}, {job.job_state}"
+                f"update_submission_state: job: {job.job_hash}, {job.job_id}, {job.job_state}"
             )
 
     def handle_unexpected_submission_state(self):
@@ -818,7 +816,7 @@ class Job:
         this method will not submit or resubmit the jobs if the job is unsubmitted.
         """
         dlog.debug(
-            f"debug:query database; self.job_hash:{self.job_hash}; self.job_id:{self.job_id}"
+            f"query database; self.job_hash:{self.job_hash}; self.job_id:{self.job_id}"
         )
         assert self.machine is not None
         job_state = self.machine.check_status(self)
@@ -838,7 +836,7 @@ class Job:
         if job_state == JobStatus.terminated:
             self.fail_count += 1
             dlog.info(
-                f"job: {self.job_hash} {self.job_id} terminated; "
+                f"job {self.job_hash} {self.job_id} terminated; "
                 f"fail_cout is {self.fail_count}; resubmitting job"
             )
             retry_count = 3
@@ -848,7 +846,7 @@ class Job:
             if (self.fail_count) > 0 and (self.fail_count % retry_count == 0):
                 last_error_message = self.get_last_error_message()
                 err_msg = (
-                    f"job:{self.job_hash} {self.job_id} failed {self.fail_count} times."
+                    f"job {self.job_hash} {self.job_id} failed {self.fail_count} times."
                 )
                 if last_error_message is not None:
                     err_msg += f"\nPossible remote error message: {last_error_message}"
@@ -856,24 +854,24 @@ class Job:
             self.submit_job()
             if self.job_state != JobStatus.unsubmitted:
                 dlog.info(
-                    f"job:{self.job_hash} re-submit after terminated; new job_id is {self.job_id}"
+                    f"job {self.job_hash} re-submit after terminated; new job_id is {self.job_id}"
                 )
                 time.sleep(0.2)
                 self.get_job_state()
                 dlog.info(
-                    f"job:{self.job_hash} job_id:{self.job_id} after re-submitting; the state now is {repr(self.job_state)}"
+                    f"job {self.job_hash} job_id:{self.job_id} after re-submitting; the state now is {repr(self.job_state)}"
                 )
                 self.handle_unexpected_job_state()
             if self.resources.wait_time != 0:
                 time.sleep(self.resources.wait_time)
 
         if job_state == JobStatus.unsubmitted:
-            dlog.debug(f"job: {self.job_hash} unsubmitted; submit it")
+            dlog.debug(f"job {self.job_hash} unsubmitted; submit it")
             # if self.fail_count > 3:
             #     raise RuntimeError("job:job {job} failed 3 times".format(job=self))
             self.submit_job()
             if self.job_state != JobStatus.unsubmitted:
-                dlog.info(f"job: {self.job_hash} submit; job_id is {self.job_id}")
+                dlog.info(f"job {self.job_hash} was submitted; job_id is {self.job_id}")
             if self.resources.wait_time != 0:
                 time.sleep(self.resources.wait_time)
             # self.get_job_state()

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -600,24 +600,56 @@ class Task:
         return sha1(json.dumps(self.serialize()).encode("utf-8")).hexdigest()
 
     @classmethod
-    def load_from_json(cls, json_file):
+    def load_from_json(cls, json_file: str, allow_ref: bool = False) -> "Task":
+        """Load a Task from a JSON file.
+
+        Parameters
+        ----------
+        json_file : str
+            Path to task JSON file.
+        allow_ref : bool, default=False
+            Whether to allow loading external JSON/YAML snippets via ``$ref``.
+            Disabled by default for security.
+        """
         with open(json_file) as f:
             task_dict = json.load(f)
-        return cls.load_from_dict(task_dict)
+        return cls.load_from_dict(task_dict, allow_ref=allow_ref)
 
     @classmethod
-    def load_from_yaml(cls, yaml_file):
+    def load_from_yaml(cls, yaml_file: str, allow_ref: bool = False) -> "Task":
+        """Load a Task from a YAML file.
+
+        Parameters
+        ----------
+        yaml_file : str
+            Path to task YAML file.
+        allow_ref : bool, default=False
+            Whether to allow loading external JSON/YAML snippets via ``$ref``.
+            Disabled by default for security.
+        """
         with open(yaml_file) as f:
             task_dict = yaml.safe_load(f)
-        task = cls.load_from_dict(task_dict=task_dict)
+        task = cls.load_from_dict(task_dict=task_dict, allow_ref=allow_ref)
         return task
 
     @classmethod
-    def load_from_dict(cls, task_dict: dict) -> "Task":
+    def load_from_dict(cls, task_dict: dict, allow_ref: bool = False) -> "Task":
+        """Load a Task from a dict.
+
+        Parameters
+        ----------
+        task_dict : dict
+            Task configuration dict.
+        allow_ref : bool, default=False
+            Whether to allow loading external JSON/YAML snippets via ``$ref``.
+            Disabled by default for security.
+        """
         # check dict
         base = cls.arginfo()
-        task_dict = base.normalize_value(task_dict, trim_pattern="_*")
-        base.check_value(task_dict, strict=False)
+        task_dict = base.normalize_value(
+            task_dict, trim_pattern="_*", allow_ref=allow_ref
+        )
+        base.check_value(task_dict, strict=False, allow_ref=allow_ref)
 
         task = cls.deserialize(task_dict=task_dict)
         return task
@@ -1103,11 +1135,23 @@ class Resources:
         return resources
 
     @classmethod
-    def load_from_dict(cls, resources_dict):
+    def load_from_dict(cls, resources_dict: dict, allow_ref: bool = False):
+        """Load Resources from a dict.
+
+        Parameters
+        ----------
+        resources_dict : dict
+            Resources configuration dict.
+        allow_ref : bool, default=False
+            Whether to allow loading external JSON/YAML snippets via ``$ref``.
+            Disabled by default for security.
+        """
         # check dict
         base = cls.arginfo(detail_kwargs="batch_type" in resources_dict)
-        resources_dict = base.normalize_value(resources_dict, trim_pattern="_*")
-        base.check_value(resources_dict, strict=False)
+        resources_dict = base.normalize_value(
+            resources_dict, trim_pattern="_*", allow_ref=allow_ref
+        )
+        base.check_value(resources_dict, strict=False, allow_ref=allow_ref)
 
         return cls.deserialize(resources_dict=resources_dict)
 

--- a/dpdispatcher/utils/dpcloudserver/client.py
+++ b/dpdispatcher/utils/dpcloudserver/client.py
@@ -141,7 +141,7 @@ class Client:
         #  res = get("/tools/sts_token", {})
         res = self.get("/data/get_sts_token", {})
         # print('debug>>>>>>>>>>>>>', res)
-        dlog.debug(f"debug: _get_oss_bucket: res:{res}")
+        dlog.debug(f"_get_oss_bucket: res:{res}")
         auth = oss2.StsAuth(
             res["AccessKeyId"], res["AccessKeySecret"], res["SecurityToken"]
         )
@@ -149,7 +149,7 @@ class Client:
 
     def download(self, oss_file, save_file, endpoint, bucket_name):
         bucket = self._get_oss_bucket(endpoint, bucket_name)
-        dlog.debug(f"debug: download: oss_file:{oss_file}; save_file:{save_file}")
+        dlog.debug(f"download: oss_file:{oss_file}; save_file:{save_file}")
         bucket.get_object_to_file(oss_file, save_file)
         return save_file
 
@@ -180,7 +180,7 @@ class Client:
 
     def upload(self, oss_task_zip, zip_task_file, endpoint, bucket_name):
         dlog.debug(
-            f"debug: upload: oss_task_zip:{oss_task_zip}; zip_task_file:{zip_task_file}"
+            f"upload: oss_task_zip:{oss_task_zip}; zip_task_file:{zip_task_file}"
         )
         bucket = self._get_oss_bucket(endpoint, bucket_name)
         total_size = os.path.getsize(zip_task_file)

--- a/examples/dpdisp_run.py
+++ b/examples/dpdisp_run.py
@@ -18,7 +18,9 @@
 # group_size = 0
 # [[tool.dpdispatcher.task_list]]
 # # no need to contain the script filename
-# command = "python"
+# # `uv run` supports dependencies declared in the PEP-723 format
+# # See: https://docs.astral.sh/uv/guides/scripts/
+# command = "uv run"
 # # can be a glob pattern
 # task_work_path = "./"
 # forward_files = []

--- a/examples/submit_example.json
+++ b/examples/submit_example.json
@@ -1,0 +1,27 @@
+{
+    "work_base": "0_md/",
+    "machine": {
+        "batch_type": "Shell",
+        "local_root": "./",
+        "context_type": "LazyLocalContext"
+    },
+    "resources": {
+        "number_node": 1,
+        "cpu_per_node": 1,
+        "gpu_per_node": 0,
+        "queue_name": "",
+        "group_size": 1
+    },
+    "forward_common_files": [],
+    "backward_common_files": [],
+    "task_list": [
+        {
+            "command": "echo hello",
+            "task_work_path": "task1/",
+            "forward_files": [],
+            "backward_files": [],
+            "outlog": "log",
+            "errlog": "err"
+        }
+    ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     'paramiko',
-    'dargs>=0.4.1',
+    'dargs>=0.5.0',
     'requests',
     'tqdm>=4.9.0',
     'typing_extensions; python_version < "3.7"',
@@ -60,7 +60,7 @@ docs = [
     'sphinx-book-theme',
     'numpydoc',
     'deepmodeling-sphinx>=0.3.0',
-    'dargs>=0.3.1',
+    'dargs>=0.5.0',
     'sphinx-argparse<0.5.0',
 ]
 cloudserver = ["oss2", "tqdm", "bohrium-sdk"]

--- a/skills/dpdisp-submit/SKILL.md
+++ b/skills/dpdisp-submit/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: dpdisp-submit
+description: Run Shell commands as computational jobs, on local machines or HPC clusters, through Shell, Slurm, PBS, LSF, Bohrium, etc.
+compatibility: Requires uv and access to the internet.
+license: LGPL-3.0-or-later
+metadata:
+  author: deepmodeling
+  version: '1.0'
+---
+
+# dpdisp-submit
+
+This skill uses the DPDispatcher tool to run Shell commands as computational jobs, on local machines or HPC clusters, through Shell, Slurm, PBS, LSF, Bohrium, etc.
+
+## Agent responsibilities
+
+1. Execute `uvx --with dpdispatcher dargs doc dpdispatcher.entrypoints.submit.submission_args` to learn what information needs to be filled.
+1. Collect enough information from the user in plain language.
+1. Generate `submission.json` yourself (do **not** ask the user to hand-write it).
+1. Validate `submission.json` before submission.
+1. Submit with `uvx --from dpdispatcher dpdisp submit submission.json`.
+1. For long-running work, delegate execution to a sub-agent/worker when available and report progress.
+
+## Ask the user in plain language
+
+Before this step, always execute `uvx --with dpdispatcher dargs doc dpdispatcher.entrypoints.submit.submission_args` to learn what information needs to be filled.
+
+If information is missing, ask questions users can understand, for example:
+
+- Where should this run: your local machine or a remote HPC cluster?
+- What shell command should be executed?
+- How many CPUs/GPUs/nodes do you need?
+- Which queue/partition/account should we use (if applicable)?
+- Which input files should be uploaded, and which output files should be collected?
+
+## Generate `submission.json` from user input
+
+According the result of `uvx --with dpdispatcher dargs doc dpdispatcher.entrypoints.submit.submission_args`, translate user answers into:
+
+- `machine` (where/how to run),
+- `resources` (compute resources),
+- `task_list` (which shell commands/files to run).
+
+### Simple local shell tasks
+
+When the user asks for a simple local shell task, prefer these defaults to avoid common failures:
+
+- `machine.context_type = "LazyLocalContext"`
+- `machine.batch_type = "Shell"`
+- `task_list[0].task_work_path = "."` (avoid non-existing subdirectory failures)
+- `resources.group_size = 1`
+
+## Required commands
+
+```bash
+# 1) Print full submission schema
+uvx --with dpdispatcher dargs doc dpdispatcher.entrypoints.submit.submission_args
+
+# 2) Syntax check JSON
+uv run -m json.tool submission.json >/dev/null
+
+# 3) Validate generated submission.json
+uvx --with dpdispatcher dargs check -f dpdispatcher.entrypoints.submit.submission_args submission.json
+
+# 4) Submit
+uvx --from dpdispatcher dpdisp submit submission.json
+```
+
+Useful flags:
+
+- `--dry-run`
+- `--exit-on-submit`
+- `--allow-ref`
+
+## Example (agent-generated input)
+
+User request (natural language):
+
+- "Please run `echo hello world` on my local machine."
+
+Agent-generated `submission.json`:
+
+```json
+{
+  "work_base": ".",
+  "machine": {
+    "batch_type": "Shell",
+    "local_root": "./",
+    "context_type": "LazyLocalContext"
+  },
+  "resources": {
+    "number_node": 1,
+    "cpu_per_node": 1,
+    "gpu_per_node": 0,
+    "queue_name": "",
+    "group_size": 1
+  },
+  "forward_common_files": [],
+  "backward_common_files": [],
+  "task_list": [
+    {
+      "command": "echo hello world",
+      "task_work_path": ".",
+      "forward_files": [],
+      "backward_files": [],
+      "outlog": "log",
+      "errlog": "err"
+    }
+  ]
+}
+```
+
+Then run:
+
+```bash
+uv run -m json.tool submission.json >/dev/null
+uvx --with dpdispatcher dargs check -f dpdispatcher.entrypoints.submit.submission_args submission.json
+uvx --from dpdispatcher dpdisp submit submission.json
+```
+
+## What to report back to the user
+
+- A short summary of what the user asked for (where to run, command, resources).
+- Submission status (started/running/finished/failed).
+- Output locations (for example `log` and `err` when `task_work_path` is `.`).

--- a/skills/dpdisp-submit/SKILL.md
+++ b/skills/dpdisp-submit/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: dpdisp-submit
-description: Run Shell commands as computational jobs, on local machines or HPC clusters, through Shell, Slurm, PBS, LSF, Bohrium, etc.
+description: >
+  Run Shell commands as computational jobs, on local machines or HPC clusters, through Shell, Slurm, PBS, LSF, Bohrium, etc.
+  USE WHEN the user needs to submit batch jobs to a cluster, run commands on a remote server, execute tasks via job schedulers (Slurm, PBS, LSF), or safely run long-term/background shell commands that require state tracking and auto-recovery.
 compatibility: Requires uv and access to the internet.
 license: LGPL-3.0-or-later
 metadata:
@@ -14,20 +16,22 @@ This skill uses the DPDispatcher tool to run Shell commands as computational job
 
 ## Agent responsibilities
 
-1. Execute `uvx --with dpdispatcher dargs doc dpdispatcher.entrypoints.submit.submission_args` to learn what information needs to be filled.
 1. Collect enough information from the user in plain language.
-1. Generate `submission.json` yourself (do **not** ask the user to hand-write it).
+1. Generate the submission JSON file based on collected user input.
 1. Validate `submission.json` before submission.
 1. Submit with `uvx --from dpdispatcher dpdisp submit submission.json`.
-1. For long-running work, delegate execution to a sub-agent/worker when available and report progress.
+1. Automatically manage job interruptions and retries by relying on built-in state tracking (see the "Resuming Jobs" section for details).
+1. **CRITICAL SECURITY CONSTRAINT: DO NOT attempt direct SSH connections.** Never attempt to connect to the remote HPC directly using `ssh`, write custom Paramiko/Fabric Python scripts, or manually execute remote commands. Just generate the `submission.json` and use the `dpdisp submit` tool. DPDispatcher will handle all remote connections, file transfers, and job management safely.
 
-## Ask the user in plain language
+## Autonomous Information Gathering & User Prompts
 
 Before this step, always execute `uvx --with dpdispatcher dargs doc dpdispatcher.entrypoints.submit.submission_args` to learn what information needs to be filled.
 
 If information is missing, ask questions users can understand, for example:
 
 - Where should this run: your local machine or a remote HPC cluster?
+- Are there any existing configuration files?
+- Is any sensitive information in the environment variables?
 - What shell command should be executed?
 - How many CPUs/GPUs/nodes do you need?
 - Which queue/partition/account should we use (if applicable)?
@@ -41,6 +45,23 @@ According the result of `uvx --with dpdispatcher dargs doc dpdispatcher.entrypoi
 - `resources` (compute resources),
 - `task_list` (which shell commands/files to run).
 
+If the user indicates that a specific value (like a username, token, or remote path) should be read from a local environment variable, format that value in the JSON template as `${ENV_VAR_NAME}`.
+*Example:* `"remote_root": "${USER_HPC_WORKSPACE}"`
+
+### Handling Environment Variables
+
+If the user specifies values that must be loaded from local environment variables (e.g., sensitive tokens, dynamic paths), do **not** write them directly into the final JSON. Instead:
+
+1. Generate a `submission.template.json` file using the `${VAR_NAME}` syntax **only for the variables you intend to substitute**.
+   *Example:* `"remote_root": "${USER_HPC_WORKSPACE}"`
+1. Use `envsubst` with an explicit variable list to inject only those variables and create the final file. This avoids accidentally expanding unrelated `$...` tokens in the JSON (such as a `"$ref"` key):
+   `envsubst '${USER_HPC_WORKSPACE}' < submission.template.json > submission.json`
+1. **CRITICAL SECURITY CONSTRAINT: DO NOT read or print the contents of the newly generated `submission.json` file.** Once `envsubst` replaces the variables, the file contains raw sensitive data. Reading it will leak these secrets into your context, which is strictly prohibited.
+
+If multiple environment variables are needed, list them all explicitly in the `envsubst` call, for example:
+`envsubst '${USER_HPC_WORKSPACE} ${USER_OTHER_VAR}' < submission.template.json > submission.json`
+If no environment variables are needed, simply generate `submission.json` directly.
+
 ### Simple local shell tasks
 
 When the user asks for a simple local shell task, prefer these defaults to avoid common failures:
@@ -52,59 +73,103 @@ When the user asks for a simple local shell task, prefer these defaults to avoid
 
 ## Required commands
 
+### Core Flow
+
 ```bash
 # 1) Print full submission schema
 uvx --with dpdispatcher dargs doc dpdispatcher.entrypoints.submit.submission_args
 
-# 2) Syntax check JSON
+# 2) [Optional] Substitute environment variables if a template was generated
+envsubst '${USER_VAR} ${USER_OTHER_VAR}' < submission.template.json > submission.json
+
+# 3) Syntax check JSON
 uv run -m json.tool submission.json >/dev/null
 
-# 3) Validate generated submission.json
+# 4) Validate generated submission.json
 uvx --with dpdispatcher dargs check -f dpdispatcher.entrypoints.submit.submission_args submission.json
 
-# 4) Submit
+# 5) Submit
 uvx --from dpdispatcher dpdisp submit submission.json
 ```
 
-Useful flags:
+### Best Practices for Long-Running Jobs
 
-- `--dry-run`
-- `--exit-on-submit`
-- `--allow-ref`
+When executing tasks that are expected to take a long time, it is important to avoid losing the monitoring process due to SSH timeouts or closed terminals. Use one of the following approaches:
 
-## Example (agent-generated input)
+- **Wrap in `tmux`:** Run the `dpdisp submit` command inside a `tmux` session. This keeps the process alive and allows you to detach and reattach safely if your network connection drops.
+- **Use the `--exit-on-submit` flag:** Add this flag if you only need to submit the job and return immediately. This exits as soon as the job has been successfully handed off to the scheduling system (for example, Slurm), without waiting for execution to finish or for outputs to be downloaded. However, a successful return from `dpdisp submit` with `--exit-on-submit` is **not** a signal that the overall job is finished. It only confirms successful submission. A separate follow-up step is still required to monitor job status and verify that results have been downloaded back to the local workspace.
 
-User request (natural language):
+### More Useful Flags
 
-- "Please run `echo hello world` on my local machine."
+- **`--dry-run`**: Parses the configuration, generates local directories, and validates the schema, but does **not** actually submit the job to the machine or cluster. Useful for a final safety check before real execution.
+- **`--allow-ref`**: Allows nesting and referencing other JSON files using `{"$ref": "other.json"}` for reusable config snippets. The referenced file is loaded first, and then the current file's fields override or extend it. If your configuration uses `$ref`, you should also pass `--allow-ref` to ***all related*** validation and submission commands (for example, `dargs check` and `dpdisp submit`). Otherwise, the config may fail to parse or validate even if the JSON content itself is correct.
 
-Agent-generated `submission.json`:
+## Submission vs. Completion
+
+It is important to distinguish between **successful submission** and **full completion**:
+
+1. **Successfully Submitted**
+
+- The `dpdisp submit` command exits with a success code (`0`).
+- If `--exit-on-submit` is used, this only means the job was accepted and submitted to the backend scheduler.
+- At this stage, the tasks may still be queued or running, and output files may not yet be available locally.
+
+2. **Fully Completed**
+   A job is considered **fully completed** only when both of the following are true:
+
+- The backend tasks have finished successfully.
+- All required output files (for example, `log`, `err`, and result files) have been retrieved to the local `task_work_path`.
+
+## Resuming Jobs (Failure Handling & Recovery)
+
+DPDispatcher is inherently idempotent and features built-in state tracking. It will automatically resume unfinished tasks without duplicating completed ones.
+
+**When to trigger recovery:**
+
+- A job fails, times out, or gets unexpectedly interrupted.
+- The user explicitly asks to "resume", "retry", or "recover" a previously interrupted or failed job.
+- The Agent's SSH or network connection drops during job monitoring.
+
+**Action:** Do **NOT** modify `submission.json` or attempt to clean up the remote directories. Simply re-execute the exact same submission command (such as `uvx --from dpdispatcher dpdisp submit submission.json --allow-ref`) in the same directory. The tool will safely skip successful tasks and only resubmit or resume the pending/failed ones.
+
+## Example
+
+User request:
+
+- "Please run `run_simulation.sh` on my Slurm cluster. Load my username from `$HPC_USER` and the workspace path from `$HPC_WORKDIR`. We already have a `resource_defaults.json` for the base compute settings, please use it and just add the debug queue."
+
+Assume `resource_defaults.json` already exists in the directory.
+Agent-generated `submission.template.json`:
 
 ```json
 {
   "work_base": ".",
   "machine": {
-    "batch_type": "Shell",
-    "local_root": "./",
-    "context_type": "LazyLocalContext"
+    "batch_type": "Slurm",
+    "context_type": "SSHContext",
+    "remote_profile": {
+      "hostname": "login.cluster.edu",
+      "username": "${HPC_USER}",
+      "port": 22
+    },
+    "remote_root": "${HPC_WORKDIR}/dpdisp_run"
   },
   "resources": {
-    "number_node": 1,
-    "cpu_per_node": 1,
-    "gpu_per_node": 0,
-    "queue_name": "",
+    "$ref": "resource_defaults.json",
+    "queue_name": "debug",
     "group_size": 1
   },
-  "forward_common_files": [],
-  "backward_common_files": [],
   "task_list": [
     {
-      "command": "echo hello world",
-      "task_work_path": ".",
-      "forward_files": [],
-      "backward_files": [],
-      "outlog": "log",
-      "errlog": "err"
+      "command": "bash run_simulation.sh",
+      "task_work_path": "task_000",
+      "forward_files": [
+        "run_simulation.sh",
+        "input.dat"
+      ],
+      "backward_files": [
+        "result.out"
+      ]
     }
   ]
 }
@@ -113,9 +178,11 @@ Agent-generated `submission.json`:
 Then run:
 
 ```bash
+envsubst '${HPC_USER} ${HPC_WORKDIR}' < submission.template.json > submission.json
 uv run -m json.tool submission.json >/dev/null
-uvx --with dpdispatcher dargs check -f dpdispatcher.entrypoints.submit.submission_args submission.json
-uvx --from dpdispatcher dpdisp submit submission.json
+uvx --with dpdispatcher dargs check --allow-ref -f dpdispatcher.entrypoints.submit.submission_args submission.json
+tmux new-session -d -s dpdisp_job "uvx --from dpdispatcher dpdisp submit --allow-ref submission.json"
+tmux ls
 ```
 
 ## What to report back to the user
@@ -123,3 +190,4 @@ uvx --from dpdispatcher dpdisp submit submission.json
 - A short summary of what the user asked for (where to run, command, resources).
 - Submission status (started/running/finished/failed).
 - Output locations (for example `log` and `err` when `task_work_path` is `.`).
+- If the job encounters an interruption or partial failure, provide the user with detailed information about this issue and offer to simply re-run the command to resume the unfinished tasks.

--- a/tests/test_allow_ref.py
+++ b/tests/test_allow_ref.py
@@ -1,0 +1,39 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from dpdispatcher.entrypoints.submit import load_submission_from_json
+
+
+class TestAllowRef(unittest.TestCase):
+    def test_submit_json_allow_ref_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            work = tmp / "work"
+            work.mkdir(parents=True, exist_ok=True)
+            (work / "task1").mkdir(exist_ok=True)
+
+            machine = tmp / "machine.json"
+            machine.write_text(
+                '{"batch_type":"Shell","context_type":"LazyLocalContext","local_root":"'
+                + tmpdir
+                + '","remote_root":"'
+                + tmpdir
+                + '"}'
+            )
+            submission = tmp / "submission.json"
+            submission.write_text(
+                "{"
+                '"work_base":"work/",'
+                '"machine":{"$ref":"machine.json"},'
+                '"resources":{"number_node":1,"cpu_per_node":1,"gpu_per_node":0,"queue_name":"","group_size":1},'
+                '"forward_common_files":[],"backward_common_files":[],'
+                '"task_list":[{"command":"echo hello","task_work_path":"task1/","forward_files":[],"backward_files":[],"outlog":"log","errlog":"err"}]'
+                "}"
+            )
+
+            with self.assertRaises(Exception):
+                load_submission_from_json(str(submission), allow_ref=False)
+
+            sub = load_submission_from_json(str(submission), allow_ref=True)
+            self.assertEqual(sub.machine.__class__.__name__, "Shell")

--- a/tests/test_class_machine_dispatch.py
+++ b/tests/test_class_machine_dispatch.py
@@ -5,7 +5,7 @@ from socket import gaierror
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 __package__ = "tests"
-from dargs.dargs import ArgumentValueError
+from dargs.dargs import ArgumentKeyError, ArgumentValueError
 
 from .context import (  # noqa: F401
     LSF,
@@ -117,9 +117,8 @@ class TestMachineDispatch(unittest.TestCase):
         # self.assertIsInstance(batch.context, SSHContext)
 
     def test_key_err(self):
-        # pass
         machine_dict = {}
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ArgumentKeyError):
             Machine.load_from_dict(machine_dict=machine_dict)
 
     def test_context_err(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,4 +11,6 @@ class TestCLI(unittest.TestCase):
             "run",
             "submit",
         ):
-            sp.check_output(["dpdisp", subcommand, "-h"])
+            output = sp.check_output(["dpdisp", subcommand, "-h"])
+            if subcommand in ("run", "submit"):
+                self.assertIn(b"--allow-ref", output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,5 +9,6 @@ class TestCLI(unittest.TestCase):
             "submission",
             "gui",
             "run",
+            "submit",
         ):
             sp.check_output(["dpdisp", subcommand, "-h"])

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -10,6 +10,7 @@ from typing import Sequence, Tuple
 from dargs import Argument
 
 from dpdispatcher.arginfo import machine_dargs, resources_dargs, task_dargs
+from dpdispatcher.entrypoints.submit import submission_args
 
 # directory of examples
 p_examples = Path(__file__).parent.parent / "examples"
@@ -17,6 +18,7 @@ p_examples = Path(__file__).parent.parent / "examples"
 machine_args = machine_dargs()
 resources_args = resources_dargs(detail_kwargs=False)
 task_args = task_dargs()
+submission_args_obj = submission_args()
 
 # input_files : tuple[tuple[Argument, Path]]
 #   tuple of example list
@@ -30,6 +32,7 @@ input_files: Sequence[Tuple[Argument, Path]] = (
     (resources_args, p_examples / "resources" / "tiger.json"),
     (task_args, p_examples / "task" / "deepmd-kit.json"),
     (task_args, p_examples / "task" / "g16.json"),
+    (submission_args_obj, p_examples / "submit_example.json"),
 )
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -7,6 +7,8 @@ from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 __package__ = "tests"
 
+from dpdispatcher.run import create_submission
+
 from .context import run
 
 
@@ -23,3 +25,52 @@ class TestRun(unittest.TestCase):
                 )
             finally:
                 os.chdir(cwd)
+
+    def test_create_submission_glob_propagates_allow_ref(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            work_base = "work"
+            task_dir = Path(temp_dir) / work_base
+            task_dir.mkdir(parents=True, exist_ok=True)
+            (task_dir / "a").mkdir(exist_ok=True)
+            (task_dir / "b").mkdir(exist_ok=True)
+
+            task_ref = Path(temp_dir) / "task.json"
+            task_ref.write_text(
+                "{"
+                '"command":"echo hello",'
+                '"task_work_path":"*",'
+                '"forward_files":[],"backward_files":[],"outlog":"log","errlog":"err"'
+                "}"
+            )
+
+            metadata = {
+                "work_base": work_base,
+                "forward_common_files": [],
+                "backward_common_files": [],
+                "machine": {
+                    "batch_type": "Shell",
+                    "context_type": "LocalContext",
+                    "local_root": temp_dir,
+                    "remote_root": temp_dir,
+                },
+                "resources": {
+                    "number_node": 1,
+                    "cpu_per_node": 1,
+                    "gpu_per_node": 0,
+                    "queue_name": "",
+                    "group_size": 1,
+                },
+                "task_list": [{"$ref": str(task_ref)}],
+            }
+
+            with self.assertRaises(Exception):
+                create_submission(metadata, script_hash="abc", allow_ref=False)
+
+            submission = create_submission(metadata, script_hash="abc", allow_ref=True)
+            self.assertEqual(len(submission.belonging_tasks), 2)
+            self.assertTrue(
+                all(
+                    task.command.endswith(" $REMOTE_ROOT/script_abc.py")
+                    for task in submission.belonging_tasks
+                )
+            )

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -56,7 +56,17 @@ class TestSubmitCommand(unittest.TestCase):
 
     def test_submit_help(self) -> None:
         """Test dpdisp submit --help."""
-        sp.check_output(["dpdisp", "submit", "-h"])  # noqa: S603, S607
+        output = sp.check_output(["dpdisp", "submit", "-h"])  # noqa: S603, S607
+        self.assertIn(b"--allow-ref", output)
+
+    def test_submit_allow_ref_flag(self) -> None:
+        """Test dpdisp submit --allow-ref."""
+        output = sp.check_output(  # noqa: S603, S607
+            ["dpdisp", "submit", "--allow-ref", "--dry-run", self.json_file],
+            cwd=self.tmpdir,
+            stderr=sp.STDOUT,
+        )
+        self.assertIn(b"submission succeeded", output)
 
     def test_submit_dry_run(self) -> None:
         """Test dpdisp submit --dry-run."""

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -1,0 +1,126 @@
+import json
+import os
+import shutil
+import subprocess as sp
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+__package__ = "tests"
+
+
+class TestSubmitCommand(unittest.TestCase):
+    """Test dpdisp submit command."""
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp()
+        self.json_file = os.path.join(self.tmpdir, "submission.json")
+        self.work_dir = os.path.join(self.tmpdir, "test_work")
+        self.task_dir = os.path.join(self.work_dir, "task1")
+        os.makedirs(self.task_dir)
+
+        # Create a simple submission JSON file
+        submission_dict = {
+            "work_base": "test_work/",
+            "machine": {
+                "batch_type": "Shell",
+                "local_root": self.tmpdir,
+                "context_type": "LazyLocalContext",
+            },
+            "resources": {
+                "number_node": 1,
+                "cpu_per_node": 1,
+                "gpu_per_node": 0,
+                "queue_name": "",
+                "group_size": 1,
+            },
+            "forward_common_files": [],
+            "backward_common_files": [],
+            "task_list": [
+                {
+                    "command": "echo hello",
+                    "task_work_path": "task1/",
+                    "forward_files": [],
+                    "backward_files": [],
+                    "outlog": "log",
+                    "errlog": "err",
+                }
+            ],
+        }
+        with open(self.json_file, "w") as f:
+            json.dump(submission_dict, f)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmpdir)
+
+    def test_submit_help(self) -> None:
+        """Test dpdisp submit --help."""
+        sp.check_output(["dpdisp", "submit", "-h"])  # noqa: S603, S607
+
+    def test_submit_dry_run(self) -> None:
+        """Test dpdisp submit --dry-run."""
+        output = sp.check_output(  # noqa: S603, S607
+            ["dpdisp", "submit", "--dry-run", self.json_file],
+            cwd=self.tmpdir,
+            stderr=sp.STDOUT,
+        )
+        self.assertIn(b"submission succeeded", output)
+
+    def test_submit_invalid_json(self) -> None:
+        """Test dpdisp submit with invalid JSON (missing required fields)."""
+        invalid_json_file = os.path.join(self.tmpdir, "invalid.json")
+        invalid_dict = {
+            "work_base": "test_work/",
+            "machine": {
+                "batch_type": "Shell",
+                "local_root": self.tmpdir,
+                "context_type": "LazyLocalContext",
+            },
+            "resources": {
+                "number_node": 1,
+                # missing required resource fields (group_size, etc.)
+            },
+            "task_list": [
+                {
+                    "command": "echo hello",
+                    "task_work_path": "task1/",
+                }
+            ],
+        }
+        with open(invalid_json_file, "w") as f:
+            json.dump(invalid_dict, f)
+
+        with self.assertRaises(sp.CalledProcessError):
+            sp.check_output(  # noqa: S603, S607
+                ["dpdisp", "submit", "--dry-run", invalid_json_file],
+                cwd=self.tmpdir,
+                stderr=sp.STDOUT,
+            )
+
+    def test_submit_and_run(self) -> None:
+        """Test dpdisp submit and run to completion."""
+        output = sp.check_output(  # noqa: S603, S607
+            ["dpdisp", "submit", self.json_file],
+            cwd=self.tmpdir,
+            stderr=sp.STDOUT,
+        )
+        # Check that the job was submitted and finished
+        self.assertIn(b"was submitted", output)
+        self.assertIn(b"finished", output)
+        # Check that the task was executed
+        log_file = os.path.join(self.task_dir, "log")
+        self.assertTrue(os.path.exists(log_file))
+        with open(log_file) as f:
+            content = f.read()
+        self.assertIn("hello", content)
+
+    def test_submit_exit_on_submit(self) -> None:
+        """Test dpdisp submit --exit-on-submit."""
+        output = sp.check_output(  # noqa: S603, S607
+            ["dpdisp", "submit", "--exit-on-submit", self.json_file],
+            cwd=self.tmpdir,
+            stderr=sp.STDOUT,
+        )
+        # Check that job was submitted (either succeeded or finished)
+        self.assertIn(b"was submitted", output)


### PR DESCRIPTION
This pull request introduces a new `submit` command to the CLI for submitting jobs from a JSON file, enhances documentation, and improves configuration and formatting workflows. The most important changes are grouped below:

---

**New Features:**

* Added a new `submit` CLI command (`dpdisp submit submission.json`) for submitting jobs from a JSON file, with support for options like `--dry-run`, `--exit-on-submit`, and `--allow-ref` for external snippet loading. (`dpdispatcher/dpdisp.py`, `dpdispatcher/entrypoints/submit.py`, `doc/submit.md`, [[1]](diffhunk://#diff-158a4f418d2da715954e210ede7c2ad6b8905c8f5b5c198db1ef82f67e971a31R8) [[2]](diffhunk://#diff-158a4f418d2da715954e210ede7c2ad6b8905c8f5b5c198db1ef82f67e971a31R98-R129) [[3]](diffhunk://#diff-158a4f418d2da715954e210ede7c2ad6b8905c8f5b5c198db1ef82f67e971a31L134-R174) [[4]](diffhunk://#diff-7e9bc34ee8981a004bdfff81a5f07c114f6e85ddefa5d680f4255be253cc2fe5R1-R154) [[5]](diffhunk://#diff-8d29ec3c4f7b457f9181b1ab19a2c0c034f9f0e4d10d916cfb7b52bd7fce79ecR1-R30)
* Added support for `$ref` in both the `run` and new `submit` commands, allowing external JSON/YAML snippets to be loaded into configurations when explicitly enabled. (`dpdispatcher/entrypoints/run.py`, `dpdispatcher/entrypoints/submit.py`, `dpdispatcher/machine.py`, [[1]](diffhunk://#diff-62b37073f9d610f6911be6fe035d3f929c6c735bbee3ec93f0470609d8349dceL6-R9) [[2]](diffhunk://#diff-d7cac59ff35317e0e13add0de83b56db47515208a92fcd52415c668f0ba9742eL138-R155) [[3]](diffhunk://#diff-6218dc2316916814c575e9ab16b8ccb73aa943b853d5c3278c840fdfbbcce500L13-R34)

**Documentation Improvements:**

* Added new documentation pages for the `submit` command (`doc/submit.md`) and for agent skills (`doc/agent-skills.md`), and updated the documentation index and references accordingly. [[1]](diffhunk://#diff-8d29ec3c4f7b457f9181b1ab19a2c0c034f9f0e4d10d916cfb7b52bd7fce79ecR1-R30) [[2]](diffhunk://#diff-3161f66a61b9ed68303607f1dbdce1c7bdcc69c42f8ea1c2051a07a579ebcf5dR36-R37) [[3]](diffhunk://#diff-87eeb6c4fb5b1129c296eac8a3a48f53ea470424f802005ef4f40e71576503f6R1-R26)
* Improved documentation formatting for example code blocks by switching to the new frontmatter style for code block options. (`doc/examples/expanse.md`, `doc/examples/g16.md`, `doc/examples/shell.md`, `doc/examples/template.md`, `doc/getting-started.md`, `doc/run.md`, [[1]](diffhunk://#diff-0259c59656564c2c18cdafcc3a80cde34ae1a8ed76c4778ad8cc59e86a517063L8-R29) [[2]](diffhunk://#diff-ec717127dd4ead0ebe6da94988529b100f30ece7fc1ded451b93290530d4946fL6-R9) [[3]](diffhunk://#diff-a550adfebce5354cd642f8ba3b42173ea3474168527d09eda326752b3bed1ee7L6-R18) [[4]](diffhunk://#diff-d64483d3ad0c5632d7ce3a1d95f96856b0cd4914e7d8091ea6a20de528ac52f1L6-R17) [[5]](diffhunk://#diff-fec82e327e0c484b9d125432afa96364f8188be4df1d7e3b102778095d347020L102-R108) [[6]](diffhunk://#diff-6218dc2316916814c575e9ab16b8ccb73aa943b853d5c3278c840fdfbbcce500L13-R34)
* Clarified and fixed minor documentation text, such as escaping `<` in timing notes and adding missing newlines. (`AGENTS.md`, [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L33-R33) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R64)

**Pre-commit and Workflow Updates:**

* Updated pre-commit hooks: upgraded `ruff` to v0.15.2, replaced `blacken-docs` with `mdformat` and several `mdformat` plugins for improved Markdown formatting, and restricted `prettier` to YAML files. (`.pre-commit-config.yaml`, [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L21-R21) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L32-R51)
* Upgraded GitHub Actions Docker-related actions to v4 for better CI reliability. (`.github/workflows/ci-docker.yml`, [.github/workflows/ci-docker.ymlL18-R28](diffhunk://#diff-9332b316f4d0b2466d2975fc710b57c5186d41091efc51181c0ad82a039b885fL18-R28))

**Code Quality and Robustness:**

* Improved error handling in SSH context by removing unused exception variables. (`dpdispatcher/contexts/ssh_context.py`, [[1]](diffhunk://#diff-e7608133a4a2e52424917b623438a21173f3aacc9def1de864b128ef87090fe4L181-R181) [[2]](diffhunk://#diff-e7608133a4a2e52424917b623438a21173f3aacc9def1de864b128ef87090fe4L203-R203)

**Internal Refactoring:**

* Refactored machine loading logic to support `$ref` and improved normalization/checking of configuration dicts. (`dpdispatcher/machine.py`, [dpdispatcher/machine.pyL138-R155](diffhunk://#diff-d7cac59ff35317e0e13add0de83b56db47515208a92fcd52415c668f0ba9742eL138-R155))

---